### PR TITLE
feat(sentiment): add sentiment analysis tool for news articles

### DIFF
--- a/python/src/tools/sentiment_tool.py
+++ b/python/src/tools/sentiment_tool.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Dict, Any
+
+from src.tools.search_news import search_news
+from src.services.llm import llm_service
+
+logger = logging.getLogger(__name__)
+
+def extract_key_info_and_sentiment(query: str, language: str = "en", max_articles_to_analyze: int = 5) -> Dict[str, Any]:
+    """Analyze news articles to extract key entities and determine sentiment.
+    
+    Args:
+        query: Search news query
+        language: News language (e.g., "en")
+        max_articles_to_analyze: Maximum articles to analyze
+        
+    Returns:
+        A dictionary with sentiment analysis and key information
+    """
+    if not query:
+        logger.error("Query parameter is required")
+        return {"error": "Query parameter is required"}
+    
+    if max_articles_to_analyze < 1 or max_articles_to_analyze > 10:
+        logger.error(f"Invalid max_articles_to_analyze: {max_articles_to_analyze}")
+        return {"error": "Invalid parameter", "message": "max_articles_to_analyze must be between 1 and 10"}
+    
+    try:
+        search_result = search_news(query, language, max_articles_to_analyze)
+        
+        if "error" in search_result:
+            logger.error(f"Error searching for articles: {search_result['error']}")
+            return search_result
+        
+        articles = search_result["articles"]
+        if not articles:
+            logger.warning(f"No articles found for query: {query}")
+            return {"error": "No articles found", "message": f"No articles found for query: {query}"}
+        
+        try:
+            sentiment_analysis = llm_service.analyze_sentiment(query, articles)
+            
+            return {
+                "status": "success",
+                "result": {
+                    "query": query,
+                    "analyzed_article_count": len(articles),
+                    "overall_sentiment": sentiment_analysis["overall_sentiment"],
+                    "sentiment_confidence": sentiment_analysis["sentiment_confidence"],
+                    "key_entities": sentiment_analysis["key_entities"],
+                    "key_takeaway_summary": sentiment_analysis["key_takeaway_summary"]
+                }
+            }
+        except Exception as e:
+            logger.error(f"Error analyzing sentiment: {str(e)}")
+            return {"error": "LLM processing error", "message": str(e)}
+        
+    except Exception as e:
+        logger.error(f"Error in extract_key_info_and_sentiment: {str(e)}")
+        return {"error": "Processing error", "message": str(e)}

--- a/python/tests/test_sentiment_tool.py
+++ b/python/tests/test_sentiment_tool.py
@@ -1,0 +1,142 @@
+import unittest
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+class TestExtractKeyInfoAndSentiment(unittest.TestCase):
+    
+    def setUp(self):
+        """Check if API keys are available and skip tests if they aren't."""
+        if not os.environ.get('OPENAI_API_KEY'):
+            self.skipTest("Skipping test as missing API keys")
+    
+    @patch('src.tools.sentiment_tool.search_news')
+    @patch('src.tools.sentiment_tool.llm_service')
+    def test_successful_sentiment_analysis(self, mock_llm_service, mock_search_news):
+        # Mock search_news to return sample articles
+        mock_search_news.return_value = {
+            "articles": [
+                {
+                    "title": "Renewable Energy Investment Surges in Europe",
+                    "description": "European countries announce major funding for solar and wind projects. Investment Fund B commits $2 billion.",
+                    "url": "https://example.com/article1",
+                    "source_name": "Energy News",
+                    "published_at": "2023-01-01T12:00:00Z"
+                },
+                {
+                    "title": "Region C Leads in Green Energy Transition",
+                    "description": "Region C has achieved 50% renewable energy usage. Person X, energy minister, states 'This is just the beginning'.",
+                    "url": "https://example.com/article2",
+                    "source_name": "Climate Report",
+                    "published_at": "2023-01-02T12:00:00Z"
+                }
+            ]
+        }
+        
+        # Mock the LLM service to return sentiment analysis
+        mock_llm_service.analyze_sentiment.return_value = {
+            "overall_sentiment": "Positive",
+            "sentiment_confidence": "Medium",
+            "key_entities": {
+                "people": ["Person X", "Person Y"],
+                "organizations": ["Company A", "Investment Fund B"],
+                "locations": ["Region C", "Europe"]
+            },
+            "key_takeaway_summary": "Significant growth in renewable energy investments across Europe with Region C leading the transition."
+        }
+        
+        # Call the function with a test query
+        from src.tools.sentiment_tool import extract_key_info_and_sentiment
+        result = extract_key_info_and_sentiment("renewable energy investment", "en", 2)
+        
+        # Verify that search_news was called with the correct parameters
+        mock_search_news.assert_called_with("renewable energy investment", "en", 2)
+        
+        # Verify that the LLM service was called with the correct parameters
+        mock_llm_service.analyze_sentiment.assert_called_with("renewable energy investment", mock_search_news.return_value["articles"])
+        
+        # Verify the function returned the expected result
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["result"]["query"], "renewable energy investment")
+        self.assertEqual(result["result"]["analyzed_article_count"], 2)
+        self.assertEqual(result["result"]["overall_sentiment"], "Positive")
+        self.assertEqual(result["result"]["sentiment_confidence"], "Medium")
+        self.assertEqual(result["result"]["key_entities"]["people"], ["Person X", "Person Y"])
+        self.assertEqual(result["result"]["key_entities"]["organizations"], ["Company A", "Investment Fund B"])
+        self.assertEqual(result["result"]["key_entities"]["locations"], ["Region C", "Europe"])
+        self.assertEqual(result["result"]["key_takeaway_summary"], 
+                         "Significant growth in renewable energy investments across Europe with Region C leading the transition.")
+    
+    def test_empty_query(self):
+        # Test with an empty query
+        from src.tools.sentiment_tool import extract_key_info_and_sentiment
+        result = extract_key_info_and_sentiment("", "en")
+        
+        # Verify the error response
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Query parameter is required")
+    
+    def test_invalid_max_articles(self):
+        # Test with invalid max_articles_to_analyze
+        from src.tools.sentiment_tool import extract_key_info_and_sentiment
+        result = extract_key_info_and_sentiment("test query", "en", 15)
+        
+        # Verify the error response
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Invalid parameter")
+        self.assertEqual(result["message"], "max_articles_to_analyze must be between 1 and 10")
+    
+    @patch('src.tools.sentiment_tool.search_news')
+    def test_no_articles_found(self, mock_search_news):
+        # Mock search_news to return no articles
+        mock_search_news.return_value = {"articles": []}
+        
+        # Call the function with a test query
+        from src.tools.sentiment_tool import extract_key_info_and_sentiment
+        result = extract_key_info_and_sentiment("nonexistent topic", "en")
+        
+        # Verify the error response
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "No articles found")
+        self.assertIn("No articles found for query", result["message"])
+    
+    @patch('src.tools.sentiment_tool.search_news')
+    def test_search_error(self, mock_search_news):
+        # Mock search_news to return an error
+        mock_search_news.return_value = {"error": "API error", "message": "Rate limit exceeded"}
+        
+        # Call the function with a test query
+        from src.tools.sentiment_tool import extract_key_info_and_sentiment
+        result = extract_key_info_and_sentiment("test query", "en")
+        
+        # Verify that the search error is propagated
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "API error")
+        self.assertEqual(result["message"], "Rate limit exceeded")
+    
+    @patch('src.tools.sentiment_tool.search_news')
+    @patch('src.tools.sentiment_tool.llm_service')
+    def test_llm_processing_error(self, mock_llm_service, mock_search_news):
+        mock_search_news.return_value = {
+            "articles": [
+                {
+                    "title": "Test Article",
+                    "description": "Test Description",
+                    "url": "https://example.com/article",
+                    "source_name": "Test Source",
+                    "published_at": "2023-01-01T12:00:00Z"
+                }
+            ]
+        }
+        
+        mock_llm_service.analyze_sentiment.side_effect = Exception("LLM API Error")
+        
+        from src.tools.sentiment_tool import extract_key_info_and_sentiment
+        result = extract_key_info_and_sentiment("test query", "en")
+        
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "LLM processing error")
+        self.assertEqual(result["message"], "LLM API Error")
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
Introduced a new sentiment analysis tool that extracts key information and sentiment from news articles based on a search query. The tool includes error handling for various scenarios, such as empty queries and API errors. Additionally, comprehensive unit tests have been added to validate the functionality and robustness of the tool.