### PR TITLE
feat(config): add PORT environment variable support

### DIFF
--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -32,6 +32,7 @@ jobs:
             -e NEWSAPI_API_KEY=test-key \
             -e OPENAI_API_KEY=test-key \
             -e TEMPERATURE=0.7 \
+            -e PORT=3000 \
             news-assistant:test
           
           # Give the container time to start

--- a/python/src/config.py
+++ b/python/src/config.py
@@ -21,7 +21,7 @@ class Config:
         self.NEWSAPI_API_KEY = os.getenv("NEWSAPI_API_KEY")
         self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
         self.TEMPERATURE = os.getenv("TEMPERATURE")
-        self.PORT = int(os.getenv("PORT"))
+        self.PORT = int(os.getenv("PORT", 3000))
         
         logger.info(f"Config initialized. OPENAI_API_KEY loaded: {bool(self.OPENAI_API_KEY)}")
         logger.info(f"Config initialized. NEWSAPI_API_KEY loaded: {bool(self.NEWSAPI_API_KEY)}")

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -17,13 +17,16 @@ class TestConfig:
         config = Config()
         assert hasattr(config, "NEWSAPI_API_KEY")
         assert hasattr(config, "OPENAI_API_KEY")
+        assert hasattr(config, "PORT")
+        assert hasattr(config, "TEMPERATURE")
     
     def test_env_variables_loaded(self):
         """Test that environment variables are correctly loaded."""
-        with patch.dict('os.environ', {"NEWSAPI_API_KEY": "test_news_key", "OPENAI_API_KEY": "test_openai_key"}, clear=True):
+        with patch.dict('os.environ', {"NEWSAPI_API_KEY": "test_news_key", "OPENAI_API_KEY": "test_openai_key", "PORT": "5000"}, clear=True):
             config = Config()
             assert config.NEWSAPI_API_KEY == "test_news_key"
             assert config.OPENAI_API_KEY == "test_openai_key"
+            assert config.PORT == 5000
     
     def test_missing_env_variables(self):
         """Test behavior when environment variables are missing."""
@@ -31,10 +34,19 @@ class TestConfig:
             config = Config()
             assert config.NEWSAPI_API_KEY is None
             assert config.OPENAI_API_KEY is None
+            assert config.PORT == 3000  # Should use default value
     
     def test_partial_env_variables(self):
         """Test behavior when only some environment variables are set."""
         with patch.dict('os.environ', {"NEWSAPI_API_KEY": "new_news_key"}, clear=True):
             config = Config()
             assert config.NEWSAPI_API_KEY == "new_news_key"
-            assert config.OPENAI_API_KEY is None 
+            assert config.OPENAI_API_KEY is None
+            assert config.PORT == 3000  # Should use default value
+    
+    def test_port_env_variable(self):
+        """Test that PORT environment variable is correctly loaded and converted to int."""
+        with patch.dict('os.environ', {"PORT": "8080"}, clear=True):
+            config = Config()
+            assert config.PORT == 8080
+            assert isinstance(config.PORT, int) 


### PR DESCRIPTION
- Updated the configuration to set the PORT from environment variables, defaulting to 3000 if not provided.
- Enhanced tests to verify the loading and conversion of the PORT variable.
- Updated Docker test workflow to include PORT environment variable for container execution.